### PR TITLE
Fix vite server mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,8 @@ import {
 } from '@react-leaflet/core'
 import L, { LeafletMouseEventHandlerFn } from 'leaflet'
 import 'leaflet.markercluster'
-import './assets/MarkerCluster.css'
-import './assets/MarkerCluster.Default.css'
+import './assets/MarkerCluster.css?inline'
+import './assets/MarkerCluster.Default.css?inline'
 
 delete (L.Icon.Default as any).prototype._getIconUrl
 L.Icon.Default.mergeOptions({


### PR DESCRIPTION
Suffix to fix Vite server dev warning

This PR add the suffix `?inline` removing warning and importing correctly when running serve